### PR TITLE
fix:Vercel自动构建排除指定的分支

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,5 +7,13 @@
   ],
   "github": {
       "silent": true
+  },
+  
+  "git": {
+    "deploymentEnabled": {
+      "main": false  
+    }
   }
+  
+  
 }


### PR DESCRIPTION
去除main分支在提交commit或pr时，vercel就会自动为所有分支构建包含无效的main分支（preview）
解决此问题参考了：https://blog.csdn.net/qq_58202163/article/details/132594451
https://oragekk.me/tutorial/CI_CD/vercel-deploy.html